### PR TITLE
Fix HACS installation issue

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,7 @@
 {
     "name": "Keepsmile LED",
     "content_in_root": false,
-    "zip_release": true,
-    "filename": "keepsmileled.zip",
+    "zip_release": false,
     "render_readme": true,
     "homeassistant": "2023.11.0",
     "hacs": "1.33.0"   


### PR DESCRIPTION
If you try to install https://github.com/themooer1/keepsmile_homeassistant using [HACS](https://hacs.xyz/), it will be failed. You can find these lines in logs:
```
This error originated from a custom integration.

Logger: custom_components.hacs
Source: custom_components/hacs/repositories/base.py:986
integration: HACS (documentation, issues)
First occurred: 9:09:04 AM (4 occurrences)
Last logged: 9:26:24 AM

<Integration themooer1/keepsmile_homeassistant> Failed to download https://github.com/themooer1/keepsmile_homeassistant/releases/download/main/keepsmileled.zip
```

This PR fixes the issue